### PR TITLE
Added method to get related to model tags as array.

### DIFF
--- a/src/TaggableBehavior.php
+++ b/src/TaggableBehavior.php
@@ -65,6 +65,20 @@ class TaggableBehavior extends Behavior
     }
 
     /**
+     * @return array|string[]
+     */
+    public function getTagNamesArray()
+    {
+        if (!$this->owner->getIsNewRecord()
+            && $this->_tagNames === null
+            && !$this->owner->isRelationPopulated($this->tagRelation)) {
+            $this->populateTagNames();
+        }
+
+        return $this->_tagNames === null ? [] : $this->_tagNames;
+    }
+
+    /**
      * @param string|string[] $names
      */
     public function setTagNames($names)

--- a/src/TaggableBehavior.php
+++ b/src/TaggableBehavior.php
@@ -67,7 +67,7 @@ class TaggableBehavior extends Behavior
     /**
      * @return array|string[]
      */
-    public function getTagNamesArray()
+    public function getTagNamesAsArray()
     {
         if (!$this->owner->getIsNewRecord()
             && $this->_tagNames === null


### PR DESCRIPTION
This is pretty same method as `getTagNames()`. The only difference - array will be returned.

Usage example:
```php
<?php foreach ($model->tagNamesArray as $tag) : ?>
    <?= Html::a($tag, ['/tag/' . $tag]) ?>
<?php endforeach ?>
```