### PR TITLE
Fix of configuring example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ class Post extends \yii\db\ActiveRecord
     public function getTags()
     {
         return $this->hasMany(Tag::className(), ['id' => 'tag_id'])
-            ->viaTable('post_tag_assn', ['post_id' => 'id']);
+            ->viaTable('{{%post_tag_assn}}', ['post_id' => 'id']);
     }
 }
 ```


### PR DESCRIPTION
Need to do so, for database tablenames prefixes support. Because you've shown example of migrations with prefix support above.